### PR TITLE
make the client customizable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.md"
 keywords = ["dns", "doh"]
 description = """
-A DNS over HTTPS (DoH) library that queries public DoH servers provided by 
+A DNS over HTTPS (DoH) library that queries public DoH servers provided by
 Google and Clouflare based on `async/await`, `hyper`, and `tokio`.
 """
 
@@ -28,6 +28,7 @@ num-traits = "0.2"
 num-derive = "0.3.0"
 idna = "0.2.0"
 tokio = { version = "0.2.9", features = ["full"] }
-tower-service = "0.3.0"
+tower-service = "0.3"
+tower = "0.3"
 paste = "0.1.6"
 log = "0.4.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ num-traits = "0.2"
 num-derive = "0.3.0"
 idna = "0.2.0"
 tokio = { version = "0.2.9", features = ["full"] }
-tower-service = "0.3"
-tower = "0.3"
+tower-service = "0.3.0"
 paste = "0.1.6"
 log = "0.4.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doh-dns"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Joy Labs Engineering"]
 edition = "2018"
 repository = "https://github.com/joylabs/doh-dns"

--- a/src/client.rs
+++ b/src/client.rs
@@ -122,7 +122,6 @@ pub trait DnsClient {
 pub struct DnsResponse {
     pub Status: u32,
     pub Answer: Option<Vec<DnsAnswer>>,
-    pub Comment: Option<String>,
 }
 
 /// The data associated for requests returned by the DNS over HTTPS servers.

--- a/src/client.rs
+++ b/src/client.rs
@@ -42,7 +42,7 @@ impl Default for HyperDnsClient {
         ));
         connector.https_only(true);
         HyperDnsClient {
-            client: Client::builder().keep_alive(true).build(connector),
+            client: Client::builder().build(connector),
         }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,54 +1,107 @@
 //! HTTPS client to query DoH servers.
+use std::{
+    collections::HashMap,
+    io,
+    net::IpAddr,
+    task::{self, Poll},
+    time::Duration,
+    vec::IntoIter,
+};
+
 use async_trait::async_trait;
 use futures_util::future::{err, ok, Ready};
 use hyper::{
-    client::{connect::dns::Name, HttpConnector},
+    client::{connect::dns::InvalidNameError, connect::dns::Name, connect::Connect, HttpConnector},
     error::Result as HyperResult,
     Body, Client, Request, Response, Uri,
 };
 use hyper_tls::HttpsConnector;
-use std::{
-    io,
-    net::{IpAddr, Ipv4Addr},
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-    task::{self, Poll},
-};
+use tokio::time::timeout;
 use tower_service::Service;
+
+use crate::{dns::DnsResponse, dns::Rtype, error::QueryError, DnsHttpsServer};
 
 /// Creates a `GET` request over the given `URI` and returns its response. It is used to
 /// request data from DoH servers.
 #[async_trait]
-pub trait DnsClient: Default {
-    async fn get(&self, uri: Uri) -> HyperResult<Response<Body>>;
+pub trait DnsClient {
+    async fn request(&self, name: &str, rtype: &Rtype) -> Result<DnsResponse, QueryError>;
 }
 
-/// Hyper-based DNS client over SSL and with a static resolver to resolve DNS server names
-/// such as `dns.google` since Google does not accept request over `8.8.8.8` like Cloudflare
-/// does over `1.1.1.1`.
-pub struct HyperDnsClient {
-    client: Client<HttpsConnector<HttpConnector<UrlStaticResolver>>>,
+pub struct Builder {
+    servers: Option<Vec<DnsHttpsServer>>,
+    pool_max_idle_per_host: usize,
 }
 
-impl Default for HyperDnsClient {
-    fn default() -> HyperDnsClient {
-        let mut http_connector = HttpConnector::new_with_resolver(UrlStaticResolver::new());
+impl Default for Builder {
+    fn default() -> Builder {
+        Builder {
+            servers: Some(vec![
+                DnsHttpsServer::Google(Duration::from_secs(3)),
+                DnsHttpsServer::Cloudflare(Duration::from_secs(10)),
+            ]),
+            pool_max_idle_per_host: 1,
+        }
+    }
+}
+
+impl<'a> Builder {
+    pub fn with_servers(&'a mut self, servers: Vec<DnsHttpsServer>) -> &'a mut Self {
+        self.servers = Some(servers);
+        self
+    }
+
+    pub fn pool_max_idle_per_host(&'a mut self, max: usize) -> &'a mut Self {
+        self.pool_max_idle_per_host = max;
+        self
+    }
+
+    pub fn build(&mut self) -> HyperDnsClient {
+        let servers = self.servers.take().unwrap();
+        let mut http_connector = HttpConnector::new_with_resolver(StaticResolver::new(&servers));
         http_connector.enforce_http(false);
         let mut connector = HttpsConnector::from((
             http_connector,
             native_tls::TlsConnector::new().unwrap().into(),
         ));
         connector.https_only(true);
-        HyperDnsClient {
-            client: Client::builder().build(connector),
-        }
+
+        let client = Client::builder()
+            .pool_max_idle_per_host(self.pool_max_idle_per_host)
+            .build(connector);
+        HyperDnsClient { client, servers }
     }
 }
 
-#[async_trait]
-impl DnsClient for HyperDnsClient {
+/// Hyper-based DNS client over SSL and with a static resolver to resolve DNS server names
+/// such as `dns.google` since Google does not accept request over `8.8.8.8` like Cloudflare
+/// does over `1.1.1.1`.
+pub struct HyperDnsClient<C = HttpsConnector<HttpConnector<StaticResolver>>> {
+    client: Client<C>,
+    servers: Vec<DnsHttpsServer>,
+}
+
+impl HyperDnsClient {
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+}
+
+impl Default for HyperDnsClient {
+    fn default() -> HyperDnsClient {
+        Builder::default().build()
+    }
+}
+
+impl<C> HyperDnsClient<C>
+where
+    C: Connect,
+    C: Send + Sync + Clone + 'static,
+{
+    pub fn new(client: Client<C>, servers: Vec<DnsHttpsServer>) -> HyperDnsClient<C> {
+        HyperDnsClient { client, servers }
+    }
+
     async fn get(&self, uri: Uri) -> HyperResult<Response<Body>> {
         // The reason to build a request manually is to set the Accept header required by
         // DNS servers.
@@ -62,64 +115,101 @@ impl DnsClient for HyperDnsClient {
     }
 }
 
-// This is resolver that statically resolves the Google DNS name to 8.8.8.8 and
-// 8.8.4.4 in a round robin fashion. The Cloudflare IPs are not resolved since those
-// are already statically defined in the request URL.
-#[derive(Clone)]
-struct UrlStaticResolver {
-    round_robin: Arc<AtomicBool>,
-}
+#[async_trait]
+impl<C> DnsClient for HyperDnsClient<C>
+where
+    C: Connect,
+    C: Send + Sync + Clone + 'static,
+{
+    // Creates the HTTPS request to the server. In certain occasions, it retries to a new server
+    // if one is available.
+    async fn request(&self, name: &str, rtype: &Rtype) -> Result<DnsResponse, QueryError> {
+        // Name has to be puny encoded.
+        let name = match idna::domain_to_ascii(name) {
+            Ok(name) => name,
+            Err(e) => return Err(QueryError::InvalidName(format!("{:?}", e))),
+        };
+        let mut error = QueryError::Unknown;
+        for server in self.servers.iter() {
+            let url = format!(
+                "https://{}/{}?name={}&type={}",
+                server.domain(),
+                server.path(),
+                name,
+                rtype.1
+            );
+            let endpoint = match url.parse::<Uri>() {
+                Err(e) => return Err(QueryError::InvalidEndpoint(e.to_string(), url)),
+                Ok(endpoint) => endpoint,
+            };
 
-impl UrlStaticResolver {
-    fn new() -> UrlStaticResolver {
-        UrlStaticResolver {
-            round_robin: Arc::new(AtomicBool::new(true)),
+            error = match timeout(server.timeout(), self.get(endpoint)).await {
+                Ok(Err(e)) => QueryError::Connection(e.to_string()),
+                Ok(Ok(res)) => {
+                    match res.status().as_u16() {
+                        200 => match hyper::body::to_bytes(res).await {
+                            Err(e) => QueryError::ReadResponse(e.to_string()),
+                            Ok(body) => match serde_json::from_slice::<DnsResponse>(&body) {
+                                Err(e) => QueryError::ParseResponse(e.to_string()),
+                                Ok(res) => {
+                                    return Ok(res);
+                                }
+                            },
+                        },
+                        400 => return Err(QueryError::BadRequest400),
+                        413 => return Err(QueryError::PayloadTooLarge413),
+                        414 => return Err(QueryError::UriTooLong414),
+                        415 => return Err(QueryError::UnsupportedMediaType415),
+                        501 => return Err(QueryError::NotImplemented501),
+                        // If the following errors occur, the request will be retried on
+                        // the next server if one is available.
+                        429 => QueryError::TooManyRequests429,
+                        500 => QueryError::InternalServerError500,
+                        502 => QueryError::BadGateway502,
+                        504 => QueryError::ResolverTimeout504,
+                        _ => QueryError::Unknown,
+                    }
+                }
+                Err(_) => QueryError::Connection(format!(
+                    "connection timeout after {:?}",
+                    server.timeout()
+                )),
+            };
+            error!("request error on URL {}: {}", url, error);
         }
+        Err(error)
     }
 }
 
-impl Service<Name> for UrlStaticResolver {
-    type Response = UrlStaticAddrs;
+// This is a resolver that statically resolves the provided servers.
+#[derive(Clone)]
+pub struct StaticResolver(HashMap<Name, Vec<IpAddr>>);
+
+impl StaticResolver {
+    pub fn new(servers: &[DnsHttpsServer]) -> StaticResolver {
+        StaticResolver(
+            servers
+                .iter()
+                .map(|s| Ok::<_, InvalidNameError>((s.domain().parse()?, s.addr().to_vec())))
+                .filter_map(Result::ok)
+                .collect(),
+        )
+    }
+}
+
+impl Service<Name> for StaticResolver {
+    type Response = IntoIter<IpAddr>;
     type Error = io::Error;
-    type Future = Ready<Result<UrlStaticAddrs, io::Error>>;
+    type Future = Ready<Result<IntoIter<IpAddr>, io::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> Poll<Result<(), io::Error>> {
         Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, name: Name) -> Self::Future {
-        if name.as_str() == "dns.google" {
-            let rr_ref = Arc::clone(&self.round_robin);
-            let rr = rr_ref.load(Ordering::Relaxed);
-            let addr = if rr {
-                rr_ref.store(false, Ordering::Relaxed);
-                IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))
-            } else {
-                rr_ref.store(true, Ordering::Relaxed);
-                IpAddr::V4(Ipv4Addr::new(8, 8, 4, 4))
-            };
-            ok(UrlStaticAddrs { inner: Some(addr) })
-        } else {
-            // This should never occur.
-            err(io::Error::from(io::ErrorKind::AddrNotAvailable))
-        }
-    }
-}
-
-// This only contains one IP address so the iterator only needs to go through it once.
-struct UrlStaticAddrs {
-    inner: Option<IpAddr>,
-}
-
-impl Iterator for UrlStaticAddrs {
-    type Item = IpAddr;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(ip) = self.inner {
-            self.inner = None;
-            Some(ip)
-        } else {
-            None
+        match self.0.get(&name) {
+            Some(addrs) if addrs.len() > 0 => ok(addrs.to_vec().into_iter()),
+            _ => err(io::Error::from(io::ErrorKind::AddrNotAvailable)),
         }
     }
 }
@@ -128,10 +218,12 @@ impl Iterator for UrlStaticAddrs {
 pub mod tests {
     use super::*;
     use std::str::FromStr;
+    use std::time::Duration;
 
     #[tokio::test]
     async fn test_static_resolve() {
-        let mut resolver = UrlStaticResolver::new();
+        let mut resolver =
+            UrlStaticResolver::new(&[DnsHttpsServer::Google(Duration::from_secs(10))]);
         let n = Name::from_str("dns.google").unwrap();
         let mut g1 = resolver.call(n.clone()).await.unwrap();
         assert_eq!(g1.next(), Some(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -316,7 +316,7 @@ pub mod tests {
       "data": "167.89.118.65"
     }
   ],
-  "Comment": "Response from 2600:1801:13::1."
+  "Comment":["EDE(10): RRSIGs Missing (for DNSKEY at., id = 19294)"]
     }"#,
         )
         .unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,7 +38,7 @@ impl Error for DnsError {
 /// Errors returned in the process of generating requests and reading responsed from DoH
 /// servers. Google's HTTP response codes can be seen at <https://developers.google.com/speed/public-dns/docs/doh>
 /// and Cloudflare's at <https://developers.cloudflare.com/1.1.1.1/dns-over-https/request-structure>.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum QueryError {
     /// This error occurs if the name to be resolved cannot be encoded.
     InvalidName(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,7 @@ pub enum QueryError {
     /// This error occurs if the name to be resolved cannot be encoded.
     InvalidName(String),
     /// This error occurs if there is a problem building the query URL.
-    InvalidEndpoint(String),
+    InvalidEndpoint(String, String),
     /// This error occurs if there is a problem connecting to the server.
     Connection(String),
     /// This error occurs if there is a problem reading a response from the server.
@@ -86,7 +86,7 @@ impl fmt::Display for QueryError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             QueryError::InvalidName(ref e) => write!(f, "invalid server name given: {}", e),
-            QueryError::InvalidEndpoint(ref e) => write!(f, "invalid endpoint: {}", e),
+            QueryError::InvalidEndpoint(ref e, ref url) => write!(f, "invalid endpoint ({}): {}", url, e),
             QueryError::Connection(ref e) => write!(f, "connection error: {}", e),
             QueryError::ReadResponse(ref e) => write!(f, "error reading response: {}", e),
             QueryError::ParseResponse(ref e) => write!(f, "error parsing response: {}", e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,6 @@
 //! # Logging
 //! This library uses the `log` crate to log errors during retries. Please see that create
 //! on methods on display such errors. If no logger is setup, nothing will be logged.
-#![feature(proc_macro_hygiene)]
-#![feature(stmt_expr_attributes)]
 pub mod client;
 pub use client::DnsAnswer;
 mod dns;


### PR DESCRIPTION
Hello!

Thank you for starting this project.
I'd like to submit the changes I had to do while integrating it with a project where a custom http transport was needed.

The diff grew larger than I had imagined when I started, sorry about that.

To summarize:

- make it possible to change the transport behind the hyper client (or even not use hyper)
- have the option to configure any DoH server not already in this code base
- provide a builder for passing along the hyper client configuration
- support IPv6
- remove round robin static resolving as hyper client defaults to try all resolved IPs, this is especially useful when switching between IPv4 & IPv6

I hope that this is useful for someone else.
Oh and I didn't try the mocking of the hyper client response yet, to re-implement the retry request test.