### PR TITLE
Add HTTPS (TYPE65) support, remove deprecated function

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -42,7 +42,7 @@ impl Default for HyperDnsClient {
         ));
         connector.https_only(true);
         HyperDnsClient {
-            client: Client::builder().keep_alive(true).build(connector),
+            client: Client::builder().build(connector),
         }
     }
 }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -259,6 +259,8 @@ rtypes! {
     (txt, 16);
     /// Queries a well known service description record for the given name.
     (wks, 11);
+    /// Queries a TYPE65 (aka HTTPS) record for the given name.
+    (type65, 65);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adding HTTPS (TYPE65) support based on https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-03, this was also recently added to a very popular [go dns library](https://github.com/miekg/dns/blob/master/types.go#L85).

This is supported by Cloudflare and Google: 
```
$ curl -H 'accept: application/dns-json' 'https://cloudflare-dns.com/dns-query?name=crypto.cloudflare.com&type=TYPE65'
{"Status":0,"TC":false,"RD":true,"RA":true,"AD":true,"CD":false,"Question":[{"name":"crypto.cloudflare.com","type":65}],"Answer":[{"name":"crypto.cloudflare.com","type":65,"TTL":121,"data":"\\# 135 00 01 00 00 01 00 03 02 68 32 00 04 00 08 a2 9f 87 4f a2 9f 88 4f 00 05 00 49 00 47 fe 08 00 43 00 13 63 6c 6f 75 64 66 6c 61 72 65 2d 65 73 6e 69 2e 63 6f 6d 00 20 13 6b df ec 30 5d e8 a5 1c 0c 48 fb 28 3f ce 13 c8 61 ab 8f 0e ee ff 19 b3 27 47 d6 2d 73 58 15 00 20 00 04 00 01 00 01 00 00 00 00 00 06 00 20 26 06 47 00 00 07 00 00 00 00 00 00 a2 9f 87 4f 26 06 47 00 00 07 00 00 00 00 00 00 a2 9f 88 4f"}]}

$ curl -H 'accept: application/dns-json' 'https://dns.google/resolve?name=crypto.cloudflare.com&type=TYPE65'
{"Status": 0,"TC": false,"RD": true,"RA": true,"AD": true,"CD": false,"Question":[ {"name": "crypto.cloudflare.com.","type": 65}],"Answer":[ {"name": "crypto.cloudflare.com.","type": 65,"TTL": 299,"data": "\\# 135 0001000001000302683200040008a29f874fa29f884f000500490047fe0800430013636c6f7564666c6172652d65736e692e636f6d0020136bdfec305de8a51c0c48fb283fce13c861ab8f0eeeff19b32747d62d73581500200004000100010000000000060020260647000007000000000000a29f874f260647000007000000000000a29f884f"}],"Comment": "Response from 162.159.7.226."}
```

Also remove deprecated function `keep_alive`, `keep_alive(true)` is the default in any case.
