### PR TITLE
Remove unneeded feature declarations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,6 @@
 //! # Logging
 //! This library uses the `log` crate to log errors during retries. Please see that create
 //! on methods on display such errors. If no logger is setup, nothing will be logged.
-#![feature(proc_macro_hygiene)]
-#![feature(stmt_expr_attributes)]
 pub mod client;
 mod dns;
 pub mod error;


### PR DESCRIPTION
This allows this crate to compile on stable rust, 1.48. Previously, I was seeing these errors:

```
﻿error[E0554]: `#![feature]` may not be used on the stable release channel
  --> /home/joshw/.cargo/registry/src/github.com-1ecc6299db9ec823/doh-dns-0.2.0/src/lib.rs:59:1
   |
59 | #![feature(proc_macro_hygiene)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0554]: `#![feature]` may not be used on the stable release channel
  --> /home/joshw/.cargo/registry/src/github.com-1ecc6299db9ec823/doh-dns-0.2.0/src/lib.rs:60:1
   |
60 | #![feature(stmt_expr_attributes)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

It's unclear to me why the code originally required these features? If they were stabilized I would expect a different error, about the feature decl not beeing needed.

